### PR TITLE
Add /status endpoint

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "test"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./bin/spproxy"
+  cmd = "make build"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata", "bin"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "css"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !LICENSE
 
 !Makefile
+!.air.toml
 
 # ...even if they are in subdirectories
 !*/

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ help:
 run:
 	go run cmd/main.go data/config.yaml
 
+## test: Run all the tests
+.PHONY: test
+test:
+	go test ./...
+
 ## build: Build proxy service executable for current architecture
 .PHONY: build
 build:
@@ -32,6 +37,11 @@ build-win:
 ## build-all: Build spproxy for all architectures
 .PHONY: build-all
 build-all: build-linux build-win build-mac
+
+## install: Install pre-requisite libraries: air
+.PHONY: install
+install:
+	go install github.com/air-verse/air@latest
 
 ## start-test-spproxy: Start Test Sticky Port Proxy
 .PHONY: start-test-spproxy

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following example configuration does the following:
     "host": "localhost",
     "listen_port": "8080"
   },
-  "resources": [
+  "routes": [
     {
       "name": "Sticky",
       "endpoint": "/",
@@ -93,3 +93,11 @@ The Sticky Port Proxy has the following limitations:
 Two reasons:
 - My work had multiple web apps that fit the third limitation above that required constantly stopping and starting apps to jump between them when running them locally, which was painful.
 - More importantly, it was a good excuse to learn go.
+
+## Air hot reloading
+
+This project contains an air configuration to allow hot reloading during development.
+
+To install Air, run `make install`
+
+To run spproxy using Air, run `air <config path>`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The following example configuration does the following:
 }
 ```
 
+## Status Page
+
+When running you can visit the `/status` route and see the current sticky port as well as all the routes.  This page also allows up to update the current sticky page.
+
 ## Limitations
 
 The Sticky Port Proxy has the following limitations:

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-type Resource struct {
+type Route struct {
 	Name            string `json:"name"`
 	Endpoint        string `json:"endpoint"`
 	Port            string `json:"port"`
@@ -18,7 +18,7 @@ type Configuration struct {
 		Host        string `json:"host"`
 		Listen_port string `json:"listen_port"`
 	} `json:"server"`
-	Resources []Resource `json:"resources"`
+	Routes []Route `json:"routes"`
 }
 
 func NewConfiguration(configFilename string) (*Configuration, error) {
@@ -44,7 +44,7 @@ func NewConfiguration(configFilename string) (*Configuration, error) {
 		return nil, err
 	}
 
-	fmt.Printf("Config loaded: %v\n\n", config)
+	fmt.Printf("Config loaded Successfully\n\n")
 	return &config, nil
 }
 
@@ -55,15 +55,15 @@ func validateConfig(config *Configuration) error {
 	if strings.TrimSpace(config.Server.Listen_port) == "" {
 		return fmt.Errorf("server.listen_port not defined")
 	}
-	for i, resource := range config.Resources {
-		if strings.TrimSpace(resource.Name) == "" {
-			return fmt.Errorf("resources[%v].name not defined", i)
+	for i, route := range config.Routes {
+		if strings.TrimSpace(route.Name) == "" {
+			return fmt.Errorf("routes[%v].name not defined", i)
 		}
-		if strings.TrimSpace(resource.Endpoint) == "" {
-			return fmt.Errorf("resources[%v].endpoint not defined", i)
+		if strings.TrimSpace(route.Endpoint) == "" {
+			return fmt.Errorf("routes[%v].endpoint not defined", i)
 		}
-		if strings.TrimSpace(resource.Destination_URL) == "" {
-			return fmt.Errorf("resources[%v].destination_url not defined", i)
+		if strings.TrimSpace(route.Destination_URL) == "" {
+			return fmt.Errorf("routes[%v].destination_url not defined", i)
 		}
 	}
 	return nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,10 +11,16 @@ func Run(config *configs.Configuration) error {
 	// Create a new router
 	mux := http.NewServeMux()
 
-	// Iterate through the configuration and register the routes into the proxy cache
 	proxyCache := NewProxyCache()
-	for _, resource := range config.Resources {
-		mux.HandleFunc(resource.Endpoint, ProxyRequestHandler(resource, proxyCache))
+
+	mux.HandleFunc("/status", StatusRequestHandler(config, proxyCache))
+
+	// Iterate through the configuration and register the routes into the proxy cache
+	for _, route := range config.Routes {
+		mux.HandleFunc(route.Endpoint, ProxyRequestHandler(&route, proxyCache))
+		if route.Endpoint == "/" {
+			proxyCache.CurrentDestURL = route.Endpoint
+		}
 	}
 
 	// Run the proxy server

--- a/internal/server/spproxy_handler.go
+++ b/internal/server/spproxy_handler.go
@@ -117,6 +117,8 @@ func createProxy(url *url.URL, proxyCache *ProxyCache, route *configs.Route) {
 	if proxyCache.ProxyMap[route.Destination_URL] == nil {
 		fmt.Printf("[%s] *** Create new proxy for %s on %v ***\n", timeString(), route.Name, url)
 		proxyCache.ProxyMap[route.Destination_URL] = NewProxy(url, route)
+	} else {
+		proxyCache.ProxyMap[route.Destination_URL].Route = route
 	}
 }
 

--- a/internal/server/spproxy_handler.go
+++ b/internal/server/spproxy_handler.go
@@ -13,38 +13,63 @@ import (
 
 type ProxyCache struct {
 	CurrentDestURL string
-	CurrentPort    string
-	CurrentAppName string
-	ProxyMap       map[string]*httputil.ReverseProxy
+	ProxyMap       map[string]*ProxyRoute
 }
 
-func NewProxy(target *url.URL) *httputil.ReverseProxy {
+func (pc *ProxyCache) CurrentPort() string {
+	if pc.ProxyMap[pc.CurrentDestURL] == nil {
+		return ""
+	}
+	return pc.ProxyMap[pc.CurrentDestURL].Route.Port
+}
+
+func (pc *ProxyCache) CurrentAppName() string {
+	if pc.ProxyMap[pc.CurrentDestURL] == nil {
+		return ""
+	}
+	return pc.ProxyMap[pc.CurrentDestURL].Route.Name
+}
+
+func (pc *ProxyCache) CurrentEndpoint() string {
+	if pc.ProxyMap[pc.CurrentDestURL] == nil {
+		return ""
+	}
+	return pc.ProxyMap[pc.CurrentDestURL].Route.Endpoint
+}
+
+type ProxyRoute struct {
+	ReverseProxy *httputil.ReverseProxy
+	Route        *configs.Route
+}
+
+func NewProxy(target *url.URL, route *configs.Route) *ProxyRoute {
 	proxy := httputil.NewSingleHostReverseProxy(target)
-	return proxy
+	return &ProxyRoute{
+		ReverseProxy: proxy,
+		Route:        route,
+	}
 }
 
 func NewProxyCache() *ProxyCache {
 	return &ProxyCache{
 		CurrentDestURL: "",
-		CurrentPort:    "",
-		CurrentAppName: "",
-		ProxyMap:       make(map[string]*httputil.ReverseProxy),
+		ProxyMap:       make(map[string]*ProxyRoute),
 	}
 }
 
-func ProxyRequestHandler(resource configs.Resource, proxyCache *ProxyCache) func(http.ResponseWriter, *http.Request) {
+func ProxyRequestHandler(route *configs.Route, proxyCache *ProxyCache) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		url, err := url.Parse(resource.Destination_URL)
+		url, err := url.Parse(route.Destination_URL)
 		if err != nil {
-			log.Fatalf("Failed to create ProxyRequestHandler for %s : %v", resource.Name, err)
+			log.Fatalf("Failed to create ProxyRequestHandler for %s : %v", route.Name, err)
 		}
 
 		originalURL := r.URL.String()
 
 		// Update the headers to allow for SSL redirection
-		if resource.Endpoint == "/" && resource.Port != proxyCache.CurrentPort {
-			r.URL.Host = strings.Replace(url.Host, resource.Port, proxyCache.CurrentPort, 1)
-			r.Host = strings.Replace(url.Host, resource.Port, proxyCache.CurrentPort, 1)
+		if route.Endpoint == "/" && route.Port != proxyCache.CurrentPort() {
+			r.URL.Host = strings.Replace(url.Host, route.Port, proxyCache.CurrentPort(), 1)
+			r.Host = strings.Replace(url.Host, route.Port, proxyCache.CurrentPort(), 1)
 		} else {
 			r.URL.Host = url.Host
 			r.Host = url.Host
@@ -54,46 +79,44 @@ func ProxyRequestHandler(resource configs.Resource, proxyCache *ProxyCache) func
 
 		// Trim reverseProxyRoutePrefix
 		path := r.URL.Path
-		trimLen := len(resource.Endpoint)
-		if path[:trimLen] == resource.Endpoint {
+		trimLen := len(route.Endpoint)
+		if path[:trimLen] == route.Endpoint {
 			r.URL.Path = path[trimLen:]
 		}
 
 		// Update the sticky proxy port
-		if (resource.Endpoint != "/" || proxyCache.CurrentPort == "") && resource.Port != "" {
-			proxyCache.CurrentDestURL = resource.Destination_URL
-			proxyCache.CurrentPort = resource.Port
-			proxyCache.CurrentAppName = resource.Name
+		if (route.Endpoint != "/" || proxyCache.CurrentPort() == "") && route.Port != "" {
+			proxyCache.CurrentDestURL = route.Destination_URL
 		}
 
-		createProxy(url, proxyCache, resource)
+		createProxy(url, proxyCache, route)
 
-		// If a sticky port is defined for the current resource, remove the endpoint url segment and
+		// If a sticky port is defined for the current route, remove the endpoint url segment and
 		// redirect the client to the sticy port route via a HTTP 303 Redirect
-		if resource.Endpoint != "/" && resource.Port != "" {
-			redirectPath := originalURL[len(resource.Endpoint)-1:]
-			fmt.Printf("[%s] *** Browser redirect for %s to %s\n", timeString(), resource.Name, redirectPath)
+		if route.Endpoint != "/" && route.Port != "" {
+			redirectPath := originalURL[len(route.Endpoint)-1:]
+			fmt.Printf("[%s] *** Browser redirect for %s to %s\n", timeString(), route.Name, redirectPath)
 			http.Redirect(w, r, redirectPath, http.StatusSeeOther)
 			return
 		}
 
 		destUrl := proxyCache.CurrentDestURL
-		appName := proxyCache.CurrentAppName
-		if resource.Endpoint != "/" && resource.Port == "" {
-			destUrl = resource.Destination_URL
-			appName = resource.Name
+		appName := proxyCache.CurrentAppName()
+		if route.Endpoint != "/" && route.Port == "" {
+			destUrl = route.Destination_URL
+			appName = route.Name
 		}
 
 		// Send the request to the proxy for the sticky port
-		proxyCache.ProxyMap[destUrl].ServeHTTP(w, r)
+		proxyCache.ProxyMap[destUrl].ReverseProxy.ServeHTTP(w, r)
 		fmt.Printf("[%s] %s Request %s %s ==> %s\n", timeString(), appName, r.Method, originalURL, r.URL)
 	}
 }
 
-func createProxy(url *url.URL, proxyCache *ProxyCache, resource configs.Resource) {
-	if proxyCache.ProxyMap[resource.Destination_URL] == nil {
-		fmt.Printf("[%s] *** Create new proxy for %s on %v ***\n", timeString(), resource.Name, url)
-		proxyCache.ProxyMap[resource.Destination_URL] = NewProxy(url)
+func createProxy(url *url.URL, proxyCache *ProxyCache, route *configs.Route) {
+	if proxyCache.ProxyMap[route.Destination_URL] == nil {
+		fmt.Printf("[%s] *** Create new proxy for %s on %v ***\n", timeString(), route.Name, url)
+		proxyCache.ProxyMap[route.Destination_URL] = NewProxy(url, route)
 	}
 }
 

--- a/internal/server/statusHandler.go
+++ b/internal/server/statusHandler.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"spproxy/internal/configs"
+	"strings"
+)
+
+func StatusRequestHandler(config *configs.Configuration, proxyCache *ProxyCache) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("**** Status Endpoint ****")
+		var sb strings.Builder
+		sb.WriteString("<html>\n<head>\n<title>Sticky Port Proxy Status</title>\n</head>\n</body>\n<center>\n")
+		sb.WriteString("<h1>Sticky Port Proxy Status</h1>\n")
+		if proxyCache.ProxyMap[proxyCache.CurrentDestURL] == nil {
+			sb.WriteString("<b>No Sticky Port Set</b><p>")
+		} else {
+			sb.WriteString(fmt.Sprintf("<b>Current Port:</b> %s for %s<br>Redirects %s to %s<p>\n",
+				proxyCache.CurrentPort(), proxyCache.CurrentAppName(), proxyCache.CurrentEndpoint(), proxyCache.CurrentDestURL))
+		}
+		sb.WriteString("<h2>Routes</h2>\nClick on the URL link to update the current stick port to that route.<p>\n")
+		sb.WriteString("<table>\n<tr><th>Route Name</th><th>Sticky Port</th><th>Endpoint</th><th>URL</th></tr>\n")
+		for _, r := range config.Routes {
+			sb.WriteString(fmt.Sprintf("<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n",
+				r.Name, r.Port, r.Endpoint, buildUrlLink(config, r)))
+		}
+		sb.WriteString("</table>\n</center>\n</body>\n")
+		w.Write([]byte(sb.String()))
+	}
+}
+
+func buildUrlLink(config *configs.Configuration, route configs.Route) string {
+	if route.Endpoint == "/" {
+		return route.Destination_URL
+	}
+	url := route.Endpoint
+	if url[0] == '/' {
+		url = url[1:]
+	}
+	if len(url) > 0 && (url[len(url)-1] != '/') {
+		url = url + "/"
+	}
+	return fmt.Sprintf("<a href=\"http://%s:%s/%sstatus\">%s</a>",
+		config.Server.Host, config.Server.Listen_port, url, route.Destination_URL)
+}

--- a/internal/server/status_handler.go
+++ b/internal/server/status_handler.go
@@ -11,12 +11,38 @@ func StatusRequestHandler(config *configs.Configuration, proxyCache *ProxyCache)
 	return func(w http.ResponseWriter, r *http.Request) {
 		fmt.Println("**** Status Endpoint ****")
 		var sb strings.Builder
-		sb.WriteString("<html>\n<head>\n<title>Sticky Port Proxy Status</title>\n</head>\n</body>\n<center>\n")
+		sb.WriteString(`<html>
+		<head>
+		<title>Sticky Port Proxy Status</title>
+		<style>
+			table {
+				font-family: Arial, Helvetica, sans-serif;
+				border-collapse: collapse;
+			}
+
+			td, th {
+				border: 1px solid #ddd;
+				padding: 8px;
+			}
+
+			tr:nth-child(even){background-color: #f2f2f2;}
+
+			th {
+				padding-top: 12px;
+				padding-bottom: 12px;
+				text-align: left;
+				background-color: #555555;
+				color: white;
+			}
+		</style>
+		</head>
+		</body>
+		<center>`)
 		sb.WriteString("<h1>Sticky Port Proxy Status</h1>\n")
 		if proxyCache.ProxyMap[proxyCache.CurrentDestURL] == nil {
-			sb.WriteString("<b>No Sticky Port Set</b><p>")
+			sb.WriteString("<strong>No Sticky Port Set</strong>\n")
 		} else {
-			sb.WriteString(fmt.Sprintf("<b>Current Port:</b> %s for %s<br>Redirects %s to %s<p>\n",
+			sb.WriteString(fmt.Sprintf("Current Sticky Port <strong>%s</strong> for <strong>%s</strong> redirects <strong>%s</strong> to <strong>%s</strong><p>\n",
 				proxyCache.CurrentPort(), proxyCache.CurrentAppName(), proxyCache.CurrentEndpoint(), proxyCache.CurrentDestURL))
 		}
 		sb.WriteString("<h2>Routes</h2>\nClick on the URL link to update the current stick port to that route.<p>\n")

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -3,7 +3,7 @@
     "host": "localhost",
     "listen_port": "8080"
   },
-  "resources": [
+  "routes": [
     {
       "name": "Root",
       "endpoint": "/",


### PR DESCRIPTION
Add a /status endpoint to show the current sticky port and list all the configured routes.
Refactor the configuration to rename resources as routes.